### PR TITLE
Add an ADR tracking framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,8 +153,4 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
-#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
-#  and can be added to the global gitignore or merged into this file.  For a more nuclear
-#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -153,4 +153,8 @@ dmypy.json
 cython_debug/
 
 # PyCharm
-.idea/
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 dbt Labs, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -9,7 +9,7 @@ For any architectural/engineering decisions we make, we will create an ADR (Arch
 - The common sections that each ADR should have are:
     - Title
     - Context
+    - Options
     - Decision
-    - Status
     - Consequences
 - Use this article as a reference: [https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/docs/arch/README.md
+++ b/docs/arch/README.md
@@ -1,0 +1,15 @@
+# Architectural Design Records (ADRs)
+
+For any architectural/engineering decisions we make, we will create an ADR (Architectural Design Record) to keep track of what decision we made and why. This allows us to refer back to decisions in the future and see if the reasons we made a choice still holds true. This also allows for others to more easily understand the code. ADRs will follow this process:
+
+- They will live in the repo, under a directory `docs/arch`
+- They will be written in markdown
+- They will follow the naming convention `adr-NNNN-<decision-title>.md`
+    - `NNNN` will just be a counter starting at `0001` and will allow us easily keep the records in chronological order.
+- The common sections that each ADR should have are:
+    - Title
+    - Context
+    - Decision
+    - Status
+    - Consequences
+- Use this article as a reference: [https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)

--- a/docs/arch/templates/default.md
+++ b/docs/arch/templates/default.md
@@ -1,0 +1,33 @@
+# { Title }
+
+## Context
+
+{ A brief problem statement. Why do we need to make this decision? }
+
+## Options
+
+- { Option 1 }
+- ...
+
+### { Option 1 }
+
+#### Pro's
+
+- { Pro 1 }
+- ...
+
+#### Con's
+
+- { Con 1 }
+- ...
+
+## Decision
+
+#### Selected: { Option x }
+
+{ Justification }
+
+## Consequences
+
+- [+] { Positive consequence }
+- [-] { Negative consequence }


### PR DESCRIPTION
We will track ADRs publicly for reference by users, and in particular, adapter maintainers.